### PR TITLE
Improved performance by getting all card actions in one request

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,4 @@ To be implemented in future releases
   * add an average line
   * add 1 (or 3?) sigma above
   * add 1 (or 3?) sigma below
-# Suggestions
-* Max lead time - what's the longest anything ever took
-* Min lead time - what's the shortest anything ever took
-* Throughput (number of items completed / unit of time, week for example)
-* Cycle time, maybe not for now, since it will be a bit messy to calcule. We have to ask the user for which cycle we're going to measure. You could also just stack it in a Culumnative Flow Diagram (CFD). That's easier to calculate but harder to read.
 
-* I think that we can do a pretty good visualization as well for lead time like this:
-	* plot a diagram with all the lead times on a time-axis
-	* add an average line
-	* add 1 (or 3?) sigma above
-	* add 1 (or 3?) sigma below

--- a/README.md
+++ b/README.md
@@ -103,3 +103,8 @@ To be implemented in future releases
   * add 1 (or 3?) sigma above
   * add 1 (or 3?) sigma below
 
+# How to setup dev environment
+* run `npm install` to download all dependencies in package.json
+* set your trello api key in env. for powershell use `$env:FLUXOAPPKEY='<yourkeyhere>'`
+* set your trello secret api key in env. for powershell use `$env:FLUXOAPPSECRET='<yoursecretkeyhere>'`
+* start app with `node server.js`

--- a/server.js
+++ b/server.js
@@ -152,7 +152,7 @@ app.get("/api/boards/:boardid/lists", require_trello_login, function (req, res) 
 });
 
 app.get("/api/lists/:listid", require_trello_login, function (req, res) {
-    doTrelloRequest("https://trello.com/1/lists/" + req.params.listid + "/?cards=all", req, res);
+    doTrelloRequest("https://trello.com/1/lists/" + req.params.listid + "/cards/?actions=updateCard:idList,createCard&filter=all&fields=name,labels,actions", req, res);
 });
 
 app.get("/api/cards/:cardid", require_trello_login, function (req, res) {

--- a/server.js
+++ b/server.js
@@ -152,7 +152,7 @@ app.get("/api/boards/:boardid/lists", require_trello_login, function (req, res) 
 });
 
 app.get("/api/lists/:listid", require_trello_login, function (req, res) {
-    doTrelloRequest("https://trello.com/1/lists/" + req.params.listid + "/cards/?actions=updateCard:idList,createCard&filter=all&fields=name,labels,actions", req, res);
+    doTrelloRequest("https://trello.com/1/lists/" + req.params.listid + "/cards/?actions=updateCard:idList,createCard,copyCard,convertToCardFromCheckItem&filter=all&fields=name,labels,actions", req, res);
 });
 
 app.get("/api/cards/:cardid", require_trello_login, function (req, res) {

--- a/static/js/datarow.collection.js
+++ b/static/js/datarow.collection.js
@@ -97,8 +97,8 @@ Fluxo.Visualize.DataRowCollection = function () {
         return rowCount / totalCount * 100;
     };
 
-    this.addDataRow = function (label, card, actionResults) {
-        var dataRow = new Fluxo.Visualize.DataRow(label, card, actionResults);
+    this.addDataRow = function (label, card) {
+        var dataRow = new Fluxo.Visualize.DataRow(label, card);
         dataRows.push(dataRow);
 
         if (labels.indexOf(dataRow.label) === -1) {

--- a/static/js/datarow.js
+++ b/static/js/datarow.js
@@ -1,11 +1,10 @@
 var Fluxo = Fluxo || {};
 Fluxo.Visualize = Fluxo.Visualize || {};
 
-Fluxo.Visualize.DataRow = function (label, card, actionResults) {
+Fluxo.Visualize.DataRow = function (label, card) {
     'use strict';
     this.label = label;
     this.card = card;
-    this.actionResults = actionResults;
 
     var calculateLeadTime = function () {
         var timeDiff = Math.abs(getLastDate().getTime() - getCreateDate().getTime());
@@ -13,22 +12,22 @@ Fluxo.Visualize.DataRow = function (label, card, actionResults) {
     };
 
     var getLastDate = function () {
-        return new Date(actionResults[0].date);
+        return new Date(card.actions[0].date);
     };
 
     var getCreateDate = function () {
-        return new Date(actionResults[actionResults.length - 1].date);
+        return new Date(card.actions[card.actions.length - 1].date);
     };
 
     this.leadTime = function () {
-        if (this.actionResults.length <= 1)
+        if (card.actions.length <= 1)
             return 0;
 
         return calculateLeadTime();
     };
 
     this.leadTimeSerie = function () {
-        if (this.actionResults.length < 1)
+        if (card.actions.length < 1)
             return null;
 
         var lastDate = getLastDate(),

--- a/static/js/visualize.js
+++ b/static/js/visualize.js
@@ -13,6 +13,9 @@ var selected = {
 
 var $progress = $("#progress");
 var $progressbar = $("#progressbar");
+var progressIndex = 0;
+var progressCount = 100;
+var progressIntervalMs = 100;
 
 var leadTimeNoResults = $("#leadtime-no-results");
 leadTimeNoResults.hide();
@@ -41,7 +44,6 @@ var addLeadTimeData = function (card) {
 };
 
 var getAllActions = function (index, card, cardCount, callback) {
-    updateProgress(index, cardCount);
     addLeadTimeData(card);
 
     if (index === cardCount - 1) {
@@ -56,7 +58,6 @@ var getAllCards = function (cardsResult, callback) {
         leadTimeNoResults.show();
     }
 
-    $progressbar.attr("aria-valuemax", cardCount);
     $.each(cardsResult, function (index, card) {
         getAllActions(index, card, cardCount, callback);
     });
@@ -64,7 +65,12 @@ var getAllCards = function (cardsResult, callback) {
 
 var calculateLeadTime = function (callback) {
     var listId = selected.listIds[selected.listIds.length - 1];
+    
+    $progressbar.attr("aria-valuemax", progressCount);
+    var progressInterval = setInterval(function(){updateProgress(progressIndex++,progressCount)}, progressIntervalMs);
+    
     api.get("/api/lists/" + listId, function (cardsResult) {
+        clearInterval(progressInterval);
         getAllCards(cardsResult, callback);
     });
 };

--- a/static/js/visualize.js
+++ b/static/js/visualize.js
@@ -30,19 +30,19 @@ var getQueryVariable = function (variable) {
     return (false);
 };
 
-var addLeadTimeData = function (card, actionsResult) {
+var addLeadTimeData = function (card) {
     if (card.labels.length === 0) {
-        dataRows.addDataRow("No Label", card, actionsResult);
+        dataRows.addDataRow("No Label", card);
     } else {
         $.each(card.labels, function (index, label) {
-            dataRows.addDataRow(label.name, card, actionsResult);
+            dataRows.addDataRow(label.name, card);
         });
     }
 };
 
-var getAllActions = function (index, card, cardCount, callback, actionsResult) {
+var getAllActions = function (index, card, cardCount, callback) {
     updateProgress(index, cardCount);
-    addLeadTimeData(card, actionsResult);
+    addLeadTimeData(card);
 
     if (index === cardCount - 1) {
         $("body").removeClass("loading");
@@ -51,16 +51,14 @@ var getAllActions = function (index, card, cardCount, callback, actionsResult) {
 };
 
 var getAllCards = function (cardsResult, callback) {
-    var cardCount = cardsResult.cards.length;
+    var cardCount = cardsResult.length;
     if (cardCount === 0) {
         leadTimeNoResults.show();
     }
 
     $progressbar.attr("aria-valuemax", cardCount);
-    $.each(cardsResult.cards, function (index, card) {
-        api.get("/api/cards/" + card.id, function (actionsResult) {
-            getAllActions(index, card, cardCount, callback, actionsResult);
-        });
+    $.each(cardsResult, function (index, card) {
+        getAllActions(index, card, cardCount, callback);
     });
 };
 

--- a/tests/specs/datarow.collection.specs.js
+++ b/tests/specs/datarow.collection.specs.js
@@ -104,28 +104,34 @@ describe("DataRowCollections", function () {
         beforeEach(function () {
             datarowCollection.addDataRow("Bugs", {
                 name: "1 Hour",
-                id: 1
-            }, oneHour);
+                id: 1,
+                actions: oneHour
+            });
             datarowCollection.addDataRow("Bugs", {
                 name: "1 Day",
-                id: 2
-            }, oneDay);
+                id: 2,
+                actions: oneDay
+            });
             datarowCollection.addDataRow("Maintanance", {
                 name: "7 Days",
-                id: 3
-            }, sevenDays);
+                id: 3,
+                actions: sevenDays
+            });
             datarowCollection.addDataRow("Maintanance", {
                 name: "8 Days",
-                id: 4
-            }, eightDays);
+                id: 4,
+                actions: eightDays
+            });
             datarowCollection.addDataRow("User Story", {
                 name: "30 Days",
-                id: 5
-            }, thirtyDays);
+                id: 5,
+                actions: thirtyDays
+            });
             datarowCollection.addDataRow("User Story", {
                 name: "31 Days",
-                id: 6
-            }, thirtyOneDays);
+                id: 6,
+                actions: thirtyOneDays
+            });
         });
 
         describe("Has a totals object", function () {
@@ -286,20 +292,24 @@ describe("DataRowCollections", function () {
         beforeEach(function () {
             datarowCollection.addDataRow("Bugs", {
                 name: "1 Day",
-                id: 1
-            }, oneDay);
+                id: 1,
+                actions: oneDay
+            });
             datarowCollection.addDataRow("Maintanance", {
                 name: "1 Day",
-                id: 1
-            }, oneDay);
+                id: 1,
+                actions: oneDay
+            });
             datarowCollection.addDataRow("User Story", {
                 name: "1 Day",
-                id: 1
-            }, oneDay);
+                id: 1,
+                actions: oneDay
+            });
             datarowCollection.addDataRow("Innovation", {
                 name: "1 Day",
-                id: 2
-            }, eightDays);
+                id: 2,
+                actions: eightDays
+            });
         });
 
         it("Should have totals object with 1 cards", function () {

--- a/tests/specs/datarow.specs.js
+++ b/tests/specs/datarow.specs.js
@@ -3,11 +3,12 @@ describe("DataRows", function () {
 
     describe("A datarow with no actionResults", function () {
         var label = "Total";
-        var card = "Hello World Card";
-        var actionResults = [];
+        var card = {};
+        card.name = "Hello World Card";
+        card.actions = [];
 
         beforeEach(function () {
-            datarow = new Fluxo.Visualize.DataRow(label, card, actionResults);
+            datarow = new Fluxo.Visualize.DataRow(label, card);
         });
 
         it("Should be created", function () {
@@ -37,7 +38,7 @@ describe("DataRows", function () {
             id: 1,
             name: "Hello World Card"
         };
-        var actionResults = [{
+        card.actions = [{
             date: new Date("2015-01-03T12:00:00.000Z")
         }, {
             date: new Date("2015-01-02T00:00:00.000Z")
@@ -45,16 +46,16 @@ describe("DataRows", function () {
             date: new Date("2015-01-01T00:00:00.000Z")
         }];
 
-        var utcDate = Date.UTC(actionResults[0].date.getUTCFullYear(),
-            actionResults[0].date.getUTCMonth(),
-            actionResults[0].date.getUTCDate(),
-            actionResults[0].date.getUTCHours(),
-            actionResults[0].date.getUTCMinutes(),
-            actionResults[0].date.getUTCSeconds(),
+        var utcDate = Date.UTC(card.actions[0].date.getUTCFullYear(),
+            card.actions[0].date.getUTCMonth(),
+            card.actions[0].date.getUTCDate(),
+            card.actions[0].date.getUTCHours(),
+            card.actions[0].date.getUTCMinutes(),
+            card.actions[0].date.getUTCSeconds(),
             0);
 
         beforeEach(function () {
-            datarow = new Fluxo.Visualize.DataRow(label, card, actionResults);
+            datarow = new Fluxo.Visualize.DataRow(label, card);
         });
 
         it("Should have a correct leadTime", function () {
@@ -66,7 +67,7 @@ describe("DataRows", function () {
         });
 
         it("Should be exportable as csv string", function () {
-            expect(datarow.toString()).toEqual(label + ";" + card.name + ";2.5;" + actionResults[0].date.toISOString());
+            expect(datarow.toString()).toEqual(label + ";" + card.name + ";2.5;" + card.actions[0].date.toISOString());
         });
     });
 });


### PR DESCRIPTION
Instead of calling Trello for each card to get the actions this is now done in the /lists/ request.
Also we minimize the number of fields returned for each card.
The /list/ request takes a little longer but the overall performance is much better.

Also added copyCard and convertToCardFromCheckItem actions so that all cards will have correct createdDate.

With this approach we can't calculate progress so a fake progressbar is used instead.

Added a "setup dev environment" section in README
